### PR TITLE
Allow configuration of the node name

### DIFF
--- a/src/system_monitor.erl
+++ b/src/system_monitor.erl
@@ -39,6 +39,7 @@
         , stop_top/0
         , fmt_mfa/1
         , fmt_stack/1
+        , node_name/0
         ]).
 
 %% gen_server callbacks
@@ -245,8 +246,8 @@ report_full_status() ->
       _ ->
         <<>>
     end,
-  system_monitor_callback:produce(node_role,
-                                  [{node_role, node(), TS, iolist_to_binary(NodeReport)}]).
+  system_monitor_callback:produce(
+    node_role, [{node_role, node_name(), TS, iolist_to_binary(NodeReport)}]).
 
 %%------------------------------------------------------------------------------
 %% @doc Calculate reductions per application.
@@ -272,14 +273,16 @@ report_app_top(TS) ->
 present_results(Record, Tag, Values, TS) ->
   {ok, Thresholds} = application:get_env(?APP, top_significance_threshold),
   Threshold = maps:get(Tag, Thresholds, 0),
-  Node = node(),
   L = lists:filtermap(fun ({Key, Val}) when Val > Threshold ->
-                            {true, {Record, Node, TS, Key, Tag, Val}};
+                            {true, {Record, node_name(), TS, Key, Tag, Val}};
                           (_) ->
                             false
                       end,
                       Values),
   system_monitor_callback:produce(Record, L).
+
+node_name() ->
+    application:get_env(?APP, node_name, node()).
 
 %%--------------------------------------------------------------------
 %% @doc logs "the interesting parts" of erl_top

--- a/src/system_monitor_top.erl
+++ b/src/system_monitor_top.erl
@@ -407,7 +407,7 @@ finalize_proc_info(#pid_info{pid = Pid, initial_call = InitialCall,
           [{CurrModule, CurrFun, CurrArity, _} | _] ->
             {CurrModule, CurrFun, CurrArity}
         end,
-      #erl_top{node = node(),
+      #erl_top{node = system_monitor:node_name(),
                ts = Now,
                pid = pid_to_list(ProcInfo#pid_info.pid),
                group_leader = pid_to_list(GL),
@@ -424,7 +424,7 @@ finalize_proc_info(#pid_info{pid = Pid, initial_call = InitialCall,
                current_stacktrace = Stacktrace,
                current_function = CurrentFunction};
     undefined ->
-      #erl_top{node = node(),
+      #erl_top{node = system_monitor:node_name(),
                ts = Now,
                pid = pid_to_list(ProcInfo#pid_info.pid),
                group_leader = pid_to_list(GL),
@@ -616,7 +616,7 @@ do_get_app_top(FieldId) ->
 
 -spec fake_erl_top_msg(integer()) -> #erl_top{}.
 fake_erl_top_msg(Now) ->
-  #erl_top{ node               = node()
+  #erl_top{ node               = system_monitor:node_name()
           , ts                 = Now
           , pid                = "<42.42.42>"
           , group_leader       = "<42.42.42>"


### PR DESCRIPTION
This PR enables users to set the node name using the configuration parameter `node_name` instead of obtaining it from `node()`. This is beneficial in scenarios where multiple nodes share the same name and connect to a single PostgreSQL instance.